### PR TITLE
Bugfix - #98 dummy csv files init

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ class SMIT:
         self.root.mainloop()
 
         if self.user.dummy is True:
-            print('dummy true main detected')
             self.dummy_reload()
 
 
@@ -20,6 +19,7 @@ class SMIT:
     def dummy_reload(self) -> None:
         """Reload the root window with dummy settings.
         """
+        self.user.logger.info(' ---- Reload with dummy configuration ---- ')
         self.user = Application(True)
         self.root = AppGui(self.user)
         self.root.mainloop()

--- a/src/SMIT/application.py
+++ b/src/SMIT/application.py
@@ -228,7 +228,7 @@ class Application:
 
         # Set paths for copying dummy files
         source_dummy_csv = pl.Path('./opt/dummy_user/').absolute()
-        dest_dummy_csv = pl.Path('./.dummy/csv_workdir/daily').absolute()
+        dest_dummy_csv = pl.Path('./.dummy/csv_raw/daily').absolute()
         dest_dummy_settings = pl.Path('./.dummy/config').absolute()
 
         # Create folders which are needed before user init 
@@ -250,7 +250,7 @@ class Application:
         self.user_settings = pl.Path('./.dummy/config/dummy_settings.toml')
 
         # Logging
-        self.logger.info('Dummy user instantiated')
+        self.logger.info('Dummy user initiated')
 
     def __repr__(self) -> str:
         return f"Module '{self.__class__.__module__}.{self.__class__.__name__}'"

--- a/src/SMIT/gui/main_window.py
+++ b/src/SMIT/gui/main_window.py
@@ -52,6 +52,8 @@ class AppGui(ctk.CTk):
 
         if self.user.dummy is True:
             ctk.set_appearance_mode('dark')
+            self.user.os_tools._move_files_to_workdir('199996')
+            self.user.os_tools._move_files_to_workdir('199997')
 
         # Logger setup
         self.logger = app.logger

--- a/tests/test_filehandling.py
+++ b/tests/test_filehandling.py
@@ -56,7 +56,7 @@ def fh_tests_setup():
                 df_columns,
                 app) 
     
-# @pytest.mark.smoke
+@pytest.mark.smoke
 @pytest.mark.osinterface
 def test_move_files(fh_tests_setup):
     """Test move files method.


### PR DESCRIPTION
- `_setup_dummy_user` in `application.py`: changed destination path for raw csv files.

- Call  `_move_files_to_workdir` method with hardcoded meter numbers in `main_window.py`

- Move logging info to `dummy_reload` method in `main.py` 